### PR TITLE
Update LibreOffice minor version and make it more generic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM node:16-bullseye-slim
 
+ENV LO_VER=7.2.6
+
 WORKDIR /tmp
 RUN set -xe \
   && apt-get update \
   && apt-get -y --no-install-recommends install ca-certificates wget libxinerama1 libfontconfig1 libdbus-glib-1-2 libcairo2 libcups2 libglu1-mesa libsm6 \
   && apt-get purge -y --auto-remove \
-  && wget https://download.documentfoundation.org/libreoffice/stable/7.2.4/deb/x86_64/LibreOffice_7.2.4_Linux_x86-64_deb.tar.gz  \
-  && tar -zxvf LibreOffice_7.2.4_Linux_x86-64_deb.tar.gz
+  && wget https://download.documentfoundation.org/libreoffice/stable/${LO_VER}/deb/x86_64/LibreOffice_${LO_VER}_Linux_x86-64_deb.tar.gz  \
+  && tar -zxvf LibreOffice_${LO_VER}_Linux_x86-64_deb.tar.gz
 
-RUN dpkg -i ./LibreOffice_7.2.4.1_Linux_x86-64_deb/DEBS/*.deb && rm -rf LibreOffice_7.2.4_Linux_x86-64_deb.tar.gz ./LibreOffice_7.2.4.1_Linux_x86-64_deb
- 
+RUN dpkg -i ./LibreOffice_*_Linux_x86-64_deb/DEBS/*.deb && rm -rf LibreOffice_*_Linux_x86-64_deb.tar.gz ./LibreOffice_*_Linux_x86-64_deb
+
 # install node package
 RUN mkdir -p /home/node/carbone-api/node_modules && chown -R node:node /home/node/carbone-api
 WORKDIR /home/node/carbone-api


### PR DESCRIPTION
The LibreOffiche downloaded version is no more available. Update.