### PR TITLE
Fix default temps dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function getTemplatePath(req) {
 
   const templatePath = path.resolve(TEMPLATES_DIR, templateName);
   const ext = templatePath.split('.').pop() || '';
-  const dest = path.resolve(TEMP_DIR, 'carbone', crypto.randomBytes(48).toString('base64url') + '.' + ext);
+  const dest = path.resolve(TEMP_DIR, 'carbone_render', crypto.randomBytes(48).toString('base64url') + '.' + ext);
 
   return copyFile(templatePath, dest).then(() => dest);
 }


### PR DESCRIPTION
Not sure about this change.
But on runtime it try to copy the template into `carbone_render` and not into `carbone`. With `carbone` it fails with error.
`carbone_render` is also the default output dir in the Carbone doc.
